### PR TITLE
Characteristic: consistency between notations, references backwards.

### DIFF
--- a/tex/frido/48_StructAnneaux.tex
+++ b/tex/frido/48_StructAnneaux.tex
@@ -34,8 +34,8 @@ Un cas particulier est le cas des diviseurs de zéro.
 
 Un élément \( a\in A\) est \defe{régulier à droite}{régulier à droite} si \( ba=0\) implique \( b=0\). Il est régulier à gauche si \( ab=0\) implique \( b=0\).
 
-\begin{definition}[Éléments nilpotents et inversible]
-	On dit que \( a \in A \) est \defe{nilpotent}{élément!nilpotent} s'il existe \( n \in \eN \) tel que \( a^n = 0 \).
+\begin{definition}[Éléments nilpotents, unipotents et inversible]
+	On dit que \( a \in A \) est \defe{nilpotent}{nilpotent} s'il existe \( n \in \eN \) tel que \( a^n = 0 \). Il est dit \defe{unipotent}{unipotent} si \( a-1\) est nilpotent, c'est à dire si \( (a-1)^n =0\) pour un certain \( n \in \eN \).
 	
 	Un élément \( a \in A \) est dit \defe{inversible}{élément!inversible!dans un anneau} s'il existe \( b \in A \) tel que \( ab = 1 \).
 \end{definition}
@@ -462,7 +462,7 @@ Par exemple la caractéristique que \( \eQ\) est zéro parce qu'aucun multiple d
 \end{lemma}
 
 \begin{proof}
-    En effet, \( \ker\mu=0\) implique que \( n1_A\neq  m1_A\) et par conséquent \( A\) est infini.
+    En effet, \( \ker\mu=\{0\} \) implique que \( n1_A \neq  m1_A\) dès que \(n \neq m \) et par conséquent \( A\) contient \(\eZ 1_A \), et  est infini.
 \end{proof}
 
 \begin{lemma}       \label{LemHmDaYH}
@@ -473,7 +473,7 @@ Par exemple la caractéristique que \( \eQ\) est zéro parce qu'aucun multiple d
 \end{lemma}
 
 \begin{proof}
-    L'isomorphisme est donné par l'application \( n1_A\mapsto \phi(n)\) si \( \phi\) est la projection canonique \( \eZ\to \eZ_p\).
+    L'isomorphisme est donné par l'application \( n1_A\mapsto \phi(n)\) si \( \phi\) est la projection canonique \( \eZ\to \eZ/p\eZ\).
 \end{proof}
 
 \begin{proposition}     \label{PropGExaUK}
@@ -481,7 +481,7 @@ Par exemple la caractéristique que \( \eQ\) est zéro parce qu'aucun multiple d
 \end{proposition}
 
 \begin{proof}
-    Si \( \eA\) est un anneau, le groupe \( \eZ\) agit sur \( \eA\) par
+    Si \( A\) est un anneau, le groupe \( \eZ\) agit sur \( A\) par
     \begin{equation}
         n\cdot a=a+n1_A.
     \end{equation}
@@ -489,7 +489,7 @@ Par exemple la caractéristique que \( \eQ\) est zéro parce qu'aucun multiple d
     \begin{equation}
         \mO_a=\{ a+n1_A\tq n=0,\ldots, p-1 \}
     \end{equation}
-    où \( p\) est la caractéristique de \( \eA\). Les orbites ont \( p\) éléments et forment une partition de \( \eA\), donc le cardinal de \( \eA\) est un multiple de \( p\).
+    où \( p\) est la caractéristique de \( A\). Les orbites ont \( p\) éléments et forment une partition de \( A\), donc le cardinal de \( A\) est un multiple de \( p\).
 \end{proof}
 
 \begin{lemma}[\cite{ooIBWOooSjOvXd}]        \label{LEMooJQIKooQgukqn}
@@ -502,23 +502,14 @@ Par exemple la caractéristique que \( \eQ\) est zéro parce qu'aucun multiple d
 
 L'ensemble typique de caractéristique \( p\) est \( \eF_p=\eZ/p\eZ\).
 
-\begin{example}
-    Soit à factoriser \( X^p-1\) dans \( \eF_p\). Grâce au morphisme de Frobenius, nous avons immédiatement
-    \begin{equation}
-        X^p-1=(X-1)^p.
-    \end{equation}
-\end{example}
 
-\begin{definition}
-    Un élément \( a\) d'un anneau est dit \defe{nilpotent}{nilpotent} si \( a^r=0\) pour un certain \( r\). Il est dit \defe{unipotent}{unipotent} si \( a-1\) est nilpotent, c'est à dire si \( (a-1)^r=0\) pour un certain \( r\).
-\end{definition}
 
 \begin{proposition}     \label{Propqrrdem}
-    Soit \( \eA\) un anneau commutatif de caractéristique première \( p\). Alors \( \sigma(x)=x^p\) est un automorphisme de l'anneau \( \eA\). Nous avons la formule
+    Soit \( A\) un anneau commutatif de caractéristique première \( p\). Alors \( \sigma(x)=x^p\) est un automorphisme de l'anneau \( A\). Nous avons la formule
     \begin{equation}
         (a+b)^p=a^p+b^p
     \end{equation}
-    pour tout \( a,b\in \eA\).
+    pour tout \( a,b\in A\).
 \end{proposition}
 
 \begin{proof}
@@ -526,10 +517,10 @@ L'ensemble typique de caractéristique \( p\) est \( \eF_p=\eZ/p\eZ\).
 \end{proof}
 
 \begin{proposition} \label{PropFrobHAMkTY}
-    Soit \( \eA\) un anneau commutatif unitaire de caractéristique \( p\). L'application
+    Soit \( A\) un anneau commutatif unitaire de caractéristique \( p\). L'application
     \begin{equation}
         \begin{aligned}
-            \Frob_\eA\colon \eA&\to \eA \\
+            \Frob_A\colon A&\to A \\
             x&\mapsto x^p 
         \end{aligned}
     \end{equation}
@@ -537,6 +528,12 @@ L'ensemble typique de caractéristique \( p\) est \( \eF_p=\eZ/p\eZ\).
 \end{proposition}
 Nous le nommons le \defe{morphisme de Frobenius}{morphisme!Frobenius}\index{Frobenius!morphisme}. Nous utiliserons aussi les itérés du morphisme de Frobenius : \( \Frob^k\colon x\mapsto x^{p^k}\).
 
+\begin{example}
+    Soit à factoriser \( X^p-1\) dans \( \eF_p\). Grâce au morphisme de Frobenius, nous avons immédiatement
+    \begin{equation}
+        X^p-1=(X-1)^p.
+    \end{equation}
+\end{example}
 
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 \section{Modules}


### PR DESCRIPTION
Éléments nilpotents, unipotents: la définition arrive bien trop tard, j'avais déjà (re)défini éléménts nilpotents, j'ai rajouté l'unipotence "en haut.
Frobenius: l'exemple l'utilisant vient maintenant après.
Utilisation de A au lieu de \eA pour les anneaux.